### PR TITLE
Persistent cache

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,9 @@
   resholve,
   lib,
   coreutils,
+  diffutils,
+  findutils,
+  gnutar,
   nix,
   writeText,
 }:
@@ -25,7 +28,7 @@ resholve.mkDerivation rec {
     default = {
       scripts = [ "share/${pname}/direnvrc" ];
       interpreter = "none";
-      inputs = [ coreutils ];
+      inputs = [ coreutils diffutils findutils gnutar ];
       fake = {
         builtin = [
           "PATH_add"
@@ -41,6 +44,8 @@ resholve.mkDerivation rec {
           "shasum"
         ];
         external = [
+          "detcache"
+          "diff"
           # We want to reference the ambient Nix when possible, and have custom logic
           # for the fallback
           "nix"

--- a/direnvrc
+++ b/direnvrc
@@ -218,6 +218,49 @@ _nix_clean_old_gcroots() {
   rm -f "$layout_dir"/{nix,flake}-profile*
 }
 
+_update_flake_profile() {
+  local layout_dir=$1
+  local profile=$2
+  local profile_rc=$3
+  local flake_uri=$4
+  shift 4
+
+  local flake_inputs="${layout_dir}/flake-inputs/"
+  local tmp_profile_rc
+  local tmp_profile="${layout_dir}/flake-tmp-profile.$$"
+  if tmp_profile_rc=$(_nix print-dev-env --profile "$tmp_profile" "$@"); then
+    # If we've gotten here, the user's current devShell is valid and we should cache it
+    _nix_clean_old_gcroots "$layout_dir"
+
+    # We need to update our cache
+    echo "$tmp_profile_rc" >"$profile_rc"
+    _nix_add_gcroot "$tmp_profile" "$profile"
+    rm -f "$tmp_profile" "$tmp_profile"*
+
+    # also add garbage collection root for source
+    local flake_input_paths
+    mkdir -p "$flake_inputs"
+    flake_input_paths=$(_nix flake archive \
+      --json --no-write-lock-file \
+      -- "$flake_uri")
+
+    while [[ $flake_input_paths =~ /nix/store/[^\"]+ ]]; do
+      local store_path="${BASH_REMATCH[0]}"
+      _nix_add_gcroot "${store_path}" "${flake_inputs}/${store_path##*/}"
+      flake_input_paths="${flake_input_paths/${store_path}/}"
+    done
+
+    _nix_direnv_info "Renewed cache"
+  else
+    # The user's current flake failed to evaluate,
+    # but there is already a prior profile_rc,
+    # which is probably more useful than nothing.
+    # Fallback to use that (which means just leaving profile_rc alone!)
+    _nix_direnv_warning "Evaluating current devShell failed. Falling back to previous environment!"
+    export NIX_DIRENV_DID_FALLBACK=1
+  fi
+}
+
 _nix_argsum_suffix() {
   local out checksum
   if [ -n "$1" ]; then
@@ -307,7 +350,6 @@ use_flake() {
   layout_dir=$(direnv_layout_dir)
   profile="${layout_dir}/flake-profile$(_nix_argsum_suffix "$flake_expr")"
   local profile_rc="${profile}.rc"
-  local flake_inputs="${layout_dir}/flake-inputs/"
 
   local need_update=0
   local watches
@@ -328,39 +370,7 @@ use_flake() {
       _nix_direnv_warn_manual_reload "$profile_rc"
 
     else
-      local tmp_profile_rc
-      local tmp_profile="${layout_dir}/flake-tmp-profile.$$"
-      if tmp_profile_rc=$(_nix print-dev-env --profile "$tmp_profile" "$@"); then
-        # If we've gotten here, the user's current devShell is valid and we should cache it
-        _nix_clean_old_gcroots "$layout_dir"
-
-        # We need to update our cache
-        echo "$tmp_profile_rc" >"$profile_rc"
-        _nix_add_gcroot "$tmp_profile" "$profile"
-        rm -f "$tmp_profile" "$tmp_profile"*
-
-        # also add garbage collection root for source
-        local flake_input_paths
-        mkdir -p "$flake_inputs"
-        flake_input_paths=$(_nix flake archive \
-          --json --no-write-lock-file \
-          -- "$flake_uri")
-
-        while [[ $flake_input_paths =~ /nix/store/[^\"]+ ]]; do
-          local store_path="${BASH_REMATCH[0]}"
-          _nix_add_gcroot "${store_path}" "${flake_inputs}/${store_path##*/}"
-          flake_input_paths="${flake_input_paths/${store_path}/}"
-        done
-
-        _nix_direnv_info "Renewed cache"
-      else
-        # The user's current flake failed to evaluate,
-        # but there is already a prior profile_rc,
-        # which is probably more useful than nothing.
-        # Fallback to use that (which means just leaving profile_rc alone!)
-        _nix_direnv_warning "Evaluating current devShell failed. Falling back to previous environment!"
-        export NIX_DIRENV_DID_FALLBACK=1
-      fi
+      _update_flake_profile "$layout_dir" "$profile" "$profile_rc" "$flake_uri" "$@"
     fi
   else
     if [[ -e ${profile_rc} ]]; then

--- a/direnvrc
+++ b/direnvrc
@@ -218,6 +218,17 @@ _nix_clean_old_gcroots() {
   rm -f "$layout_dir"/{nix,flake}-profile*
 }
 
+# Rebuild symlinks in a directory by creating nix store references
+# Returns 0 on success, 1 if any symlink couldn't be rebuilt
+_rebuild_nix_store_symlinks() {
+  local dir=$1
+  while IFS= read -r -d '' link; do
+    if ! nix build --out-link "$link" "$(realpath "$link")"; then
+      return 1
+    fi
+  done < <(find "$dir" -type l -print0)
+}
+
 _update_flake_profile() {
   local layout_dir=$1
   local profile=$2
@@ -258,6 +269,76 @@ _update_flake_profile() {
     # Fallback to use that (which means just leaving profile_rc alone!)
     _nix_direnv_warning "Evaluating current devShell failed. Falling back to previous environment!"
     export NIX_DIRENV_DID_FALLBACK=1
+  fi
+}
+
+_calculate_cache_hash() {
+  local -n _hash_input_files=$1
+  local flake_uri=${2:-}
+  local hash=$(cat <(echo "nix-direnv-cache-v1") <(echo "$flake_uri") "${_hash_input_files[@]}" 2>/dev/null | sha256sum | cut -f1 -d" ")
+  if [[ -z hash ]]; then
+    _nix_direnv_error "Failed to calculate the cache lookup hash."
+    return 1
+  fi
+  echo -n "$hash"
+}
+
+_restore_from_cache() {
+  local hash=$1
+  local layout_dir=$2
+
+  if ! command -v detcache &> /dev/null; then
+    _nix_direnv_info "Persistent caching is not available. Install the 'detcache' command to enable it."
+    return 1
+  fi
+
+  local tmp_dir
+  tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/direnv-detcache.XXXXXX")
+  if [[ ! -d "$tmp_dir" ]]; then
+    _nix_direnv_error "Failed to create temporary directory"
+    return 1
+  fi
+
+  if detcache -v get "$hash" | tar -xC "$tmp_dir" 2>/dev/null; then
+    # Check if layout_dir already contains the same content as tmp_dir
+    if [[ -d "$layout_dir" ]] && diff -r --no-dereference "$layout_dir" "$tmp_dir" &>/dev/null; then
+      _nix_direnv_info "Reusing existing environment as it matches the cache"
+      rm -rf "$tmp_dir"
+      return 0
+    fi
+
+    # Check if the extracted content has broken symlinks
+    if ! _rebuild_nix_store_symlinks "$tmp_dir"; then
+      _nix_direnv_warning "Cache contains broken symlinks, rebuilding environment"
+      rm -rf "$tmp_dir"
+      return 1
+    fi
+
+    rm -rf "$layout_dir"
+    if mv "$tmp_dir" "$layout_dir" 2>/dev/null; then
+      # After the move the GC roots will become invalid, so we have to create valid GC roots again.
+      _rebuild_nix_store_symlinks "$layout_dir"
+      _nix_direnv_info "Restored environment from cache"
+      return 0
+    fi
+  fi
+
+  rm -rf "$tmp_dir"
+  return 1
+}
+
+_store_into_cache() {
+  local hash=$1
+  local layout_dir=$2
+
+  if ! command -v detcache &> /dev/null; then
+    return 0
+  fi
+
+  if [[ -d "$layout_dir" ]]; then
+    if tar --owner=0 --group=0 -C "$layout_dir" -c . | detcache -v put "$hash"; then
+      _nix_direnv_info "Cached the environment."
+    fi
   fi
 }
 
@@ -354,6 +435,7 @@ use_flake() {
   local need_update=0
   local watches
   _nix_direnv_watches watches
+
   local file=
   for file in "${watches[@]}"; do
     if [[ $file -nt $profile_rc ]]; then
@@ -370,7 +452,13 @@ use_flake() {
       _nix_direnv_warn_manual_reload "$profile_rc"
 
     else
-      _update_flake_profile "$layout_dir" "$profile" "$profile_rc" "$flake_uri" "$@"
+      local hash=$(_calculate_cache_hash watches "$flake_uri")
+      if [[ -n "${NIX_DIRENV_DISABLE_CACHE_RESTORE:-}" ]] || ! _restore_from_cache "$hash" "$layout_dir"; then
+        _update_flake_profile "$layout_dir" "$profile" "$profile_rc" "$flake_uri" "$@"
+        if [[ "${NIX_DIRENV_DID_FALLBACK:-0}" != "1" ]]; then
+          _store_into_cache "$hash" "$layout_dir"
+        fi
+      fi
     fi
   else
     if [[ -e ${profile_rc} ]]; then


### PR DESCRIPTION
A working prototype to illustrate persistent caching in nix-direnv.

Motivation:
- to quickly restore environments in more situations (e.g. if the `.direnv` directory is removed, if file timestamps change but not the contents, if the same `.direnv` directories is used in other clones etc.).
- provide ability to share caches between machines and people (via caching in a globally available store, such as S3).

How it works:
- Calculates a hash of watched input files and some internal state. This is the key used to store and retried from the cache.
- It creates a tarball of the `.direnv` directory and stores it under the hash key.
- It uses the hash key to find a previously stored tarball, extracts it, checks that all store paths can be resolved with nix, and simply overwrites `.direnv` if all checks out.